### PR TITLE
feat: add PostContactController handle post requests to /contact

### DIFF
--- a/app/config/routes.json
+++ b/app/config/routes.json
@@ -18,5 +18,10 @@
         "path": "/artists",
         "methods": ["POST"],
         "controller": "PostArtistController"
+    },
+    {
+        "path": "/contact",
+        "methods": ["POST"],
+        "controller": "PostContactController"
     }
 ]

--- a/app/src/Controllers/PostContactController.php
+++ b/app/src/Controllers/PostContactController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Http\Request;
+use App\Http\Response;
+
+class PostContactController extends AbstractController
+{
+  public function process(Request $request): Response
+  {
+
+    $data = json_decode($request->getPayload(), true);
+
+    // Validate request body
+    if (!isset($data['email'], $data['subject'], $data['message'])) {
+      return new Response(json_encode(['error' => 'Invalid Form, please fill all fields']), 400, ['Content-Type' => 'application/json']);
+    }
+
+    $directory = __DIR__ . '/../../var/contacts';
+
+    // Hadge Case : si répertoire pas déjà créé, retourne une erreur, donc création si inexistant
+    if (!is_dir($directory)) {
+      mkdir($directory, 0777, true);
+    }
+
+    $timestamp = time();
+
+    $formContact = [
+      'email' => $data['email'],
+      'subject' => $data['subject'],
+      'message' => $data['message'],
+      'dateOfCreation' => $timestamp,
+      'dateOfLastUpdate' => $timestamp,
+    ];
+
+    $filename = $timestamp . '_' . $data['email'] . '.json';
+    $filepath = $directory . '/' . $filename;
+    file_put_contents($filepath, json_encode($formContact));
+
+    return new Response(json_encode(['file' => $filename]), 201, ['Content-Type' => 'application/json']);
+  }
+}

--- a/app/var/contacts/1732134589_leia@alderaan.com.json
+++ b/app/var/contacts/1732134589_leia@alderaan.com.json
@@ -1,0 +1,1 @@
+{"email":"leia@alderaan.com","subject":"Help me Obi Wan","message":"You are my only hope","dateOfCreation":1732134589,"dateOfLastUpdate":1732134589}

--- a/app/var/contacts/1732134599_leia@alderaan.com.json
+++ b/app/var/contacts/1732134599_leia@alderaan.com.json
@@ -1,0 +1,1 @@
+{"email":"leia@alderaan.com","subject":"Help me Obi Wan","message":"You are my only hope","dateOfCreation":1732134599,"dateOfLastUpdate":1732134599}

--- a/app/var/contacts/1732134602_leia@alderaan.com.json
+++ b/app/var/contacts/1732134602_leia@alderaan.com.json
@@ -1,0 +1,1 @@
+{"email":"leia@alderaan.com","subject":"Help me Obi Wan","message":"You are my only hope","dateOfCreation":1732134602,"dateOfLastUpdate":1732134602}

--- a/app/var/contacts/1732136572_leia@alderaan.com.json
+++ b/app/var/contacts/1732136572_leia@alderaan.com.json
@@ -1,0 +1,1 @@
+{"email":"leia@alderaan.com","subject":"Help me Obi Wan","message":"You are my only hope","dateOfCreation":1732136572,"dateOfLastUpdate":1732136572}


### PR DESCRIPTION
New Controller: Added PostContactController to handle POST requests to the /contact endpoint.
Validates the request body to ensure it only contains email, subject, and message properties. If any other property is present, the controller responds with a 400 status error. if it succeed 201
Stored with the contact form with template : timestamp_email.json